### PR TITLE
Cleans up `src` folder after download and build

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -27,3 +27,6 @@ cp "$ASDF_DOWNLOAD_PATH/src/SourceDocs-$ASDF_INSTALL_VERSION/.build/release/sour
 
 # Remove the tar.gz file since we don't need to keep it
 rm "$release_file"
+
+# Remove src folder so it doesn't get installed
+rm -rf "$ASDF_DOWNLOAD_PATH/src"


### PR DESCRIPTION
Removing `src` after building, so that the `install` script does not install it as well.

The [install script](https://github.com/asdf-vm/asdf-plugin-template/blob/bfe9f59dbced8a7600ff41f8c4538fc769fd484f/template/lib/utils.bash#L61-L62) will otherwise copy the entire contents of `$ASDF_DOWNLOAD_PATH` into the installation directory. This causes a lot of confirmation steps on my maching:

```
$ asdf install sourcedocs latest
[...]
Build complete! (25.27s)
sourcedocs 2.0.2 installation was successful!
override r--r--r-- ullrich/staff for /Users/ullrich/.asdf/downloads/sourcedocs/2.0.2/src/SourceDocs-2.0.2/.build/checkouts/swift-argument-parser/CODE_OF_CONDUCT.md? y
override r--r--r-- ullrich/staff for /Users/ullrich/.asdf/downloads/sourcedocs/2.0.2/src/SourceDocs-2.0.2/.build/checkouts/swift-argument-parser/Tools/changelog-authors/Util.swift? y
override r--r--r-- ullrich/staff for /Users/ullrich/.asdf/downloads/sourcedocs/2.0.2/src/SourceDocs-2.0.2/.build/checkouts/swift-argument-parser/Tools/changelog-authors/Models.swift? y
[...a thousand more...]
```